### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ func main() {
 	// Configure the Loki hook
 	opts := lokirus.NewLokiHookOptions().
 		// Grafana doesn't have a "panic" level, but it does have a "critical" level
-  // https://grafana.com/docs/grafana/latest/explore/logs-integration/
+ 	 // https://grafana.com/docs/grafana/latest/explore/logs-integration/
 		WithLevelMap(lokirus.LevelMap{logrus.PanicLevel: "critical"}).
-    WithFormatter(&logrus.JsonFormatter{})
+   		WithFormatter(&logrus.JSONFormatter{}).
 		WithStaticLabels(lokirus.Labels{
 			"app":         "example",
 			"environment": "development",


### PR DESCRIPTION
Correcting missspellings.

 - Adding "." to the End of `WithFormatter` to call another function after this function
 - Spelling `JsonFormatter` throws an error on `GOLAND` correcting in `JSONFormatter`

Example: 
![image](https://user-images.githubusercontent.com/46808966/188962348-82dc355e-61ca-4543-a0ed-5bb5b176dbc3.png)

IntelliJ:
![image](https://user-images.githubusercontent.com/46808966/188962395-4899e4c4-1a7b-4b7c-989f-c2ab2408fe19.png)

After:
![image](https://user-images.githubusercontent.com/46808966/188962427-fdc968ab-4352-4284-8f57-a738b88f6909.png)

